### PR TITLE
Incremental rollsum incorrectly calculated - sum(0, windowSize) + Roll() != sum(1, windowSize+1)

### DIFF
--- a/pkg/rollsum/rollsum.go
+++ b/pkg/rollsum/rollsum.go
@@ -43,7 +43,7 @@ func New() *RollSum {
 }
 
 func (rs *RollSum) add(drop, add uint8) {
-	rs.s1 += uint32(add) - uint32(drop)
+	rs.s1 += uint32(add + charOffset) - uint32(drop + charOffset)
 	rs.s2 += rs.s1 - uint32(windowSize)*uint32(drop+charOffset)
 }
 

--- a/pkg/rollsum/rollsum.go
+++ b/pkg/rollsum/rollsum.go
@@ -43,8 +43,8 @@ func New() *RollSum {
 }
 
 func (rs *RollSum) add(drop, add uint8) {
-	rs.s1 += uint32(add + charOffset) - uint32(drop + charOffset)
-	rs.s2 += rs.s1 - uint32(windowSize)*uint32(drop+charOffset)
+	rs.s1 += uint32(add) - uint32(drop)
+	rs.s2 += rs.s1 - uint32(windowSize)*(uint32(drop) + charOffset)
 }
 
 func (rs *RollSum) Roll(ch byte) {

--- a/pkg/rollsum/rollsum_test.go
+++ b/pkg/rollsum/rollsum_test.go
@@ -28,11 +28,16 @@ func TestSum(t *testing.T) {
 		buf[i] = uint8(rnd.Intn(256))
 	}
 
-	sum := func(offset, len int) uint32 {
+	roll := func(offset, len int) *RollSum {
 		rs := New()
 		for count := offset; count < len; count++ {
 			rs.Roll(buf[count])
 		}
+		return rs
+	}
+
+	sum := func(offset, len int) uint32 {
+		rs := roll(offset, len)
 		return rs.Digest()
 	}
 
@@ -51,6 +56,21 @@ func TestSum(t *testing.T) {
 	}
 	if sum3a != sum3b {
 		t.Errorf("sum3a=%d sum3b=%d", sum3a, sum3b)
+	}
+
+	end := 500
+	rs := roll(0, windowSize)
+	for i := 0; i < end; i++ {
+		sumRoll := rs.Digest()
+		newRoll := roll(i, i+windowSize).Digest()
+
+		if sumRoll != newRoll {
+			t.Errorf("Error: i=%d, buf[i]=%d, sumRoll=%d, newRoll=%d\n", i, buf[i], sumRoll, newRoll)
+		} else {
+			// fmt.Printf("OK:    i=%d, buf[i]=%d, sumRoll=%d, newRoll=%d\n", i, buf[i], sumRoll, newRoll)
+		}
+
+		rs.Roll(buf[i + windowSize])
 	}
 }
 


### PR DESCRIPTION
I may have misunderstood something about the functioning of the rollsum, but I noticed odd behaviour when trying to use it in my own project.

Essentially, when checking the rollsum window incrementally, using `Roll()` to add the next byte and slide the window forward one byte did not result in the same digest as creating a new RollSum for the same 64 byte window.

From prodding the code, the problem is rollsum.go:46-47: 
```
rs.s1 += uint32(add) - uint32(drop)
rs.s2 += rs.s1 - uint32(windowSize)*uint32(drop + charOffset)
```

which appears to have been ported from the librsync implementation:
```
(sum)->s1 += (unsigned char)(in) - (unsigned char)(out); \
(sum)->s2 += (sum)->s1 - (sum)->count*((unsigned char)(out)+ROLLSUM_CHAR_OFFSET); \
```

Errors only seem to appear when the charOffset would introduce an 8-bit wraparound (i.e. bytes > 225) -see the byte 226 being removed on the last OK line below.

```
OK:    i=0, buf[i]=29, buf[i+windowSize]=14, sumRoll=694670633, newRoll=694670633
OK:    i=1, buf[i]=212, buf[i+windowSize]=206, sumRoll=693694337, newRoll=693694337
OK:    i=2, buf[i]=117, buf[i+windowSize]=225, sumRoll=693296147, newRoll=693296147
OK:    i=3, buf[i]=31, buf[i+windowSize]=213, sumRoll=700375249, newRoll=700375249
OK:    i=4, buf[i]=137, buf[i+windowSize]=247, sumRoll=712309701, newRoll=712309701
OK:    i=5, buf[i]=157, buf[i+windowSize]=200, sumRoll=719518887, newRoll=719518887
OK:    i=6, buf[i]=116, buf[i+windowSize]=242, sumRoll=722335924, newRoll=722335924
OK:    i=7, buf[i]=61, buf[i+windowSize]=81, sumRoll=730595199, newRoll=730595199
OK:    i=8, buf[i]=7, buf[i+windowSize]=68, sumRoll=731845662, newRoll=731845662
OK:    i=9, buf[i]=128, buf[i+windowSize]=178, sumRoll=735852154, newRoll=735852154
OK:    i=10, buf[i]=201, buf[i+windowSize]=17, sumRoll=739130056, newRoll=739130056
OK:    i=11, buf[i]=100, buf[i+windowSize]=67, sumRoll=727067678, newRoll=727067678
OK:    i=12, buf[i]=67, buf[i+windowSize]=191, sumRoll=724907667, newRoll=724907667
OK:    i=13, buf[i]=117, buf[i+windowSize]=13, sumRoll=733039044, newRoll=733039044
OK:    i=14, buf[i]=170, buf[i+windowSize]=174, sumRoll=726224909, newRoll=726224909
OK:    i=15, buf[i]=226, buf[i+windowSize]=25, sumRoll=726485274, newRoll=726485274
Error: i=16, buf[i]=17, buf[i+windowSize]=111, sumRoll=713323358, newRoll=713306974
Error: i=17, buf[i]=50, buf[i+windowSize]=68, sumRoll=719491648, newRoll=719475264
Error: i=18, buf[i]=120, buf[i+windowSize]=59, sumRoll=720677108, newRoll=720660724
Error: i=19, buf[i]=24, buf[i+windowSize]=100, sumRoll=716680683, newRoll=716664299
Error: i=20, buf[i]=101, buf[i+windowSize]=174, sumRoll=721668910, newRoll=721652526
Error: i=21, buf[i]=95, buf[i+windowSize]=135, sumRoll=726455674, newRoll=726439290
Error: i=22, buf[i]=61, buf[i+windowSize]=238, sumRoll=729080174, newRoll=729063790
```

I don't know my modular arithmetic or C type coercion rules well enough to be completely confident of what's going on, but it appears that the second line should add the char offset *after* the conversion to uint32, so byte 226 should map to 257, not 1.

Certainly changing line 47 in this way fixes my test, as does adding the offset into the add and drop terms on line 46. Both version are included in these commits.

I suspect this may create problems if the incremental rollsums have been stored with blocks somewhere, but if the rollsums have been re-calculated for the first 64 bytes of a block then they should still be accurate.