### PR TITLE
Fixes #812 - Upload multi-GB file results in "too many open files" error

### DIFF
--- a/pkg/blobserver/localdisk/localdisk.go
+++ b/pkg/blobserver/localdisk/localdisk.go
@@ -71,11 +71,19 @@ func IsDir(root string) (bool, error) {
 	return false, nil
 }
 
-func maxOutFileHandleLimit(desired uint64) error {
+// Given a desired max number of file handles to allow, the function
+// tries to set the current ulimit to that. When running in normal mode,
+// the current limit is increased to the extent possible. When running
+// in privileged mode, there is scope for increasing the max limit also,
+// so we use that if relevant.
+func tryIncreasingFileHandleLimit(desired uint64) error {
 	var limit syscall.Rlimit
 	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit)
 	if err != nil {
 		return err
+	}
+	if limit.Cur >= desired {
+		return nil
 	}
 	ourMax := limit.Max
 	if ourMax < desired {
@@ -127,7 +135,7 @@ func New(root string) (*DiskStorage, error) {
 	if _, _, err := ds.StorageGeneration(); err != nil {
 		return nil, fmt.Errorf("Error initialization generation for %q: %v", root, err)
 	}
-	if err := maxOutFileHandleLimit(50000); err != nil {
+	if err := tryIncreasingFileHandleLimit(50000); err != nil {
 		return nil, fmt.Errorf("Error setting increasing ulimit required for temp files")
 	}
 	return ds, nil

--- a/pkg/blobserver/localdisk/receive.go
+++ b/pkg/blobserver/localdisk/receive.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"time"
 
 	"camlistore.org/pkg/blob"
 )
@@ -37,9 +38,13 @@ func (ds *DiskStorage) ReceiveBlob(blobRef blob.Ref, source io.Reader) (ref blob
 		return
 	}
 
-	tempFile, err := ioutil.TempFile(hashedDirectory, blobFileBaseName(blobRef)+".tmp")
-	if err != nil {
-		return
+	tmpFileName := blobFileBaseName(blobRef) + ".tmp"
+	var tempFile *os.File
+	tempFile = nil
+	for tempFile == nil {
+		if tempFile, err = ioutil.TempFile(hashedDirectory, tmpFileName); err != nil {
+			time.Sleep(1 * time.Second)
+		}
 	}
 
 	success := false // set true later


### PR DESCRIPTION
In this case, the server should try hard to not fail as the user isn't
trying to do anything extraordinary. Hence this commit does two things -
1. Set ulimit to a high enough value.
2. Be robust around the limit. It waits in a 1 second loop until the temp file
   can be opened.

Tested with 3GB upload which was failing earlier.
